### PR TITLE
I'm a little bit tired...

### DIFF
--- a/Src/IronJS/Core.fs
+++ b/Src/IronJS/Core.fs
@@ -2171,37 +2171,37 @@ and TypeConverter() =
   static member ToNumber(s:string) : double =
     let mutable d = 0.0
 
-    if s = null then
+    if System.String.IsNullOrWhiteSpace(s) then
       0.0
-
-    elif Double.TryParse(s, anyNumber, invariantCulture, &d) && s.Contains(",") |> not then 
-      if d = 0.0 
-        then (if s.[0] = '-' then -0.0 else 0.0)
-        else d
-
-    elif s.Length = 0 then 
-      0.0
-      
-    elif s.Length > 1 && s.[0] = '0' && (s.[1] = 'x' || s.[1] = 'X') then
-      let mutable i = 0
-
-      if System.Int32.TryParse(s.Substring(2), NumberStyles.HexNumber, invariantCulture, &i) 
-        then i |> double
-        else NaN
 
     else
-      try
-        System.Convert.ToInt32(s, 8) |> double
+      let s = s.Trim()
 
-      with
-        | _ -> 
-        let mutable bi = Unchecked.defaultof<bigint>
+      if Double.TryParse(s, anyNumber, invariantCulture, &d) && s.Contains(",") |> not then 
+        if d = 0.0 
+          then (if s.[0] = '-' then -0.0 else 0.0)
+          else d
 
-        if bigint.TryParse(s, anyNumber, invariantCulture, &bi) && not (s.Contains(",")) // HACK to fix , == .
-          then PosInf
-        elif s.Trim() = "+Infinity"
-          then PosInf
+      elif s.Length > 1 && s.[0] = '0' && (s.[1] = 'x' || s.[1] = 'X') then
+        let mutable i = 0
+
+        if System.Int32.TryParse(s.Substring(2), NumberStyles.HexNumber, invariantCulture, &i) 
+          then i |> double
           else NaN
+
+      else
+        try
+          System.Convert.ToInt32(s, 8) |> double
+
+        with
+          | _ -> 
+          let mutable bi = Unchecked.defaultof<bigint>
+
+          if bigint.TryParse(s, anyNumber, invariantCulture, &bi) && not (s.Contains(",")) // HACK to fix , == .
+            then PosInf
+          elif s.Trim() = "+Infinity"
+            then PosInf
+            else NaN
 
   static member ToNumber(d:double) : double = 
     if d = TaggedBools.True 

--- a/Src/IronJS/Native.Global.fs
+++ b/Src/IronJS/Native.Global.fs
@@ -59,8 +59,11 @@ module Global =
   let parseInt (str:string) = 
     str |> Int32.Parse |> double |> BV.Box
 
-  let parseFloat (str:string) = 
-    str |> TC.ToNumber |> BV.Box
+  let parseFloat (str:string) =
+    let trimmedString = str.TrimStart()
+    let prefixMatch = System.Text.RegularExpressions.Regex.Match(trimmedString, @"^[-+]?(Infinity|([0-9]+\.[0-9]*|[0-9]*\.[0-9]+|[0-9]+)([eE][-+]?[0-9]+)?)")
+    if prefixMatch.Success = false then nan |> BV.Box
+    else prefixMatch.Value |> TC.ToNumber |> BV.Box
 
   let isNaN (number:double) = 
     number <> number |> BV.Box

--- a/Src/IronJS/Native.Math.fs
+++ b/Src/IronJS/Native.Math.fs
@@ -30,13 +30,13 @@ module Math =
     
     math.Prototype <- env.Prototypes.Object
     math.Put("E", Math.E, Immutable)
-    math.Put("LN10", 2.302585092994046, Immutable)
-    math.Put("LN2", 0.6931471805599453, Immutable)
-    math.Put("LOG2E", 1.4426950408889634, Immutable)
-    math.Put("LOG10E", 0.4342944819032518, Immutable)
+    math.Put("LN10", Math.Log(10.0), Immutable)
+    math.Put("LN2", Math.Log(2.0), Immutable)
+    math.Put("LOG2E", 1.0 / Math.Log(2.0), Immutable)
+    math.Put("LOG10E", Math.Log10(Math.E), Immutable)
     math.Put("PI", Math.PI, Immutable)
-    math.Put("SQRT1_2", 0.7071067811865476, Immutable)
-    math.Put("SQRT2", 1.4142135623730951, Immutable)
+    math.Put("SQRT1_2", Math.Sqrt(0.5), Immutable)
+    math.Put("SQRT2", Math.Sqrt(2.0), Immutable)
 
     env.Globals.Put("Math", math, DontEnum)
 
@@ -56,7 +56,12 @@ module Math =
     let atan = Utils.createHostFunction env atan
     math.Put("atan", atan, DontEnum)
 
-    let inline atan2 a b = Math.Atan2(a, b)
+    let inline atan2 a b =
+      if Double.IsPositiveInfinity(a) && Double.IsPositiveInfinity(b) then Math.PI / 4.0
+      elif Double.IsPositiveInfinity(a) && Double.IsNegativeInfinity(b) then 3.0 * Math.PI / 4.0
+      elif Double.IsNegativeInfinity(a) && Double.IsPositiveInfinity(b) then -Math.PI / 4.0
+      elif Double.IsNegativeInfinity(a) && Double.IsNegativeInfinity(b) then -3.0 * Math.PI / 4.0
+      else Math.Atan2(a, b)
     let atan2 = new Func<double, double, double>(atan2)
     let atan2 = Utils.createHostFunction env atan2
     math.Put("atan2", atan2, DontEnum)


### PR DESCRIPTION
Fixed Atan2's handling of Infinity.
Fixed TypeConverter.ToNumber to trim strings, as per the spec. (this caused a regression in parseFloat)
Fixed TypeConverter.ToString to use the exact formatting rules from the spec.
Implemented parseFloat as per the spec, fixing the regressions and a few other failures.
