### PR TITLE
RegExp.prototype.exec

### DIFF
--- a/Src/IronJS/Core.fs
+++ b/Src/IronJS/Core.fs
@@ -172,6 +172,11 @@ and [<NoComparison>] [<StructLayout(LayoutKind.Explicit)>] BoxedValue =
       box.Tag <- TypeTags.String
       box
 
+    static member Box(value:int) =
+      let mutable box = BV()
+      box.Number <- double value
+      box
+
     static member Box(value:double) =
       let mutable box = BV()
       box.Number <- value

--- a/Src/IronJS/Native.String.fs
+++ b/Src/IronJS/Native.String.fs
@@ -97,7 +97,7 @@ module String =
     
   let internal match' (f:FO) (this:CO) (regexp:BV) =
     let regexp = regexp |> toRegExp f.Env
-    RegExp.exec f regexp (this |> TC.ToString)
+    RegExp.exec f regexp (this |> TC.ToString |> BV.Box)
 
   let private replacePattern =
     new Regex(@"\$\$|\$&|\$`|\$'|\$\d{1,2}", RegexOptions.Compiled)


### PR DESCRIPTION
Fixed most RegExp.prototype.exec issues, including those causing infinite loops in the tests.

Unfortunately, the errors that are left seem to be impossible to fix, while still using the .NET Regex engine.
