### PR TITLE
Fix attempt on the .length property when using ArrayObject

### DIFF
--- a/Src/IronJS.Runtime/Objects/ArrayObject.cs
+++ b/Src/IronJS.Runtime/Objects/ArrayObject.cs
@@ -30,6 +30,7 @@ namespace IronJS.Runtime
                 this.dense = new Descriptor[length];
                 this.isDense = true;
             }
+            this.Put("length", (double)length, DescriptorAttrs.DontEnum);
         }
 
         private void ResizeDense(uint newCapacity)


### PR DESCRIPTION
- Accessing the length property on an ArrayObject failed if the underlying array had not been previously resized (see this SO thread : http://stackoverflow.com/questions/12143437/cant-use-the-length-property-with-ironjs-and-arrayobject )
- **Fix** :  When the ArrayObject constructor is invoked the "length" attribute is
  set using an explicit call to the Put method (after underlying arrays
  initialization), the same way as in the Length property setter.
