### PR TITLE
minor typographical error

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,4 +27,4 @@ Make sure you have git installed and then run this command from a terminal windo
 * John Gietzen - ECMA3 Conformance, Sputnik Test Runner, NUnit Tests, Benchmarks (http://otac0n.com)
 * Christian Knutsson - Logo (http://lufthamn.com/)
 
-If you're interested in contributing to IronJS, fork it here on github and send me a pull request with your contributions.
+If you're interested in contributing to IronJS, fork it here on GitHub and send me a pull request with your contributions.


### PR DESCRIPTION
Correct minor typographical error from `github` to `GitHub`.